### PR TITLE
Dependnency declarations are now scanned not only on target class but

### DIFF
--- a/example/example/depin/core/collector/example.ceylon
+++ b/example/example/depin/core/collector/example.ceylon
@@ -14,6 +14,6 @@ void assertCollectorInjection(Collector<Integer> namingDoesntMatters){
 
 shared void run(){
 	Depin{
-		scanner.scan({`package`});
+		scanner.dependencies({`package`});
 	}.inject(`assertCollectorInjection`);
 }

--- a/example/example/depin/core/named/example.ceylon
+++ b/example/example/depin/core/named/example.ceylon
@@ -20,6 +20,6 @@ void printInjection(Integer? integerSum){
 
 shared void run(){
 	Depin{
-		scanner.scan({`package`});
+		scanner.dependencies({`package`});
 	}.inject(`printInjection`);
 }

--- a/example/example/depin/core/target/target.ceylon
+++ b/example/example/depin/core/target/target.ceylon
@@ -26,6 +26,6 @@ class TargetedInjection {
 
 shared void run(){
 	Depin{
-		scanner.scan({`package`});
+		scanner.dependencies({`package`});
 	}.inject(`TargetedInjection.printInjection`);
 }

--- a/example/example/depin/core/toplevel/example.ceylon
+++ b/example/example/depin/core/toplevel/example.ceylon
@@ -14,7 +14,7 @@ import herd.depin.core {
 }
 
 shared void run() {
-		value depedencencyDeclarations=scanner.scan({`package`});
+		value depedencencyDeclarations=scanner.dependencies({`package`});
 		value result=Depin(depedencencyDeclarations).inject(`topLevelInjection`);
 		assert(topLevelValue.size==result);
 }

--- a/source/herd/depin/core/aliases.ceylon
+++ b/source/herd/depin/core/aliases.ceylon
@@ -12,5 +12,5 @@ import ceylon.language.meta.declaration {
 }
 "Model which can be injected using [[Depin.inject]] method" 
 shared alias Injectable<Type> => ClassModel<Type>|ValueModel<Type>|FunctionModel<Type>;
-"Range of decalarations which can be scanned using [[scanner.scan]] function"
+"Range of decalarations which can be scanned using [[scanner.dependencies]] function"
 shared alias Scope=> ClassDeclaration|FunctionOrValueDeclaration|Package|Module;

--- a/source/herd/depin/core/annotations.ceylon
+++ b/source/herd/depin/core/annotations.ceylon
@@ -63,7 +63,7 @@ shared final annotation class DependencyAnnotation()
 	string => "dependency";
 }
 
-"Annotation used for creation of scannable declaration for [[scanner.scan]] function. Only declaration annotated with this annotation are taken in consideration when scanned. "
+"Annotation used for creation of scannable declaration for [[scanner.dependencies]] function. Only declaration annotated with this annotation are taken in consideration when scanned. "
 shared annotation DependencyAnnotation dependency() => DependencyAnnotation();
 
 see(`function target`)

--- a/source/herd/depin/core/module.ceylon
+++ b/source/herd/depin/core/module.ceylon
@@ -28,7 +28,7 @@
    To use this framework, one first needs to provide dependencies, for further injection. 
    It is done using [[scanner]] object. Scanning is gathering of methods  and values declaration annotated with [[dependency]].
    They can be nested in classes and member classes or top level, any formal declaration will be rejected. 
-   The [[scanner.scan]] call would provide declarations for further use. This function, takes [[Scope]]s as paremeters.
+   The [[scanner.dependencies]] call would provide declarations for further use. This function, takes [[Scope]]s as paremeters.
    [[Scope]] is range on which scanning would execute. When declaration are allready scaned they can be used for, [[Depin]] class object creation. 
    [[Depin]] will convert declarations into [[Dependency]]'ies  and provide [[Depin.inject]] method.
    Now the injection can happen. [[Depin.inject]] requires [[Injectable]] parameter which is alias for class, function or value model to which injection will happen. 

--- a/source/herd/depin/core/scanner.ceylon
+++ b/source/herd/depin/core/scanner.ceylon
@@ -13,6 +13,8 @@ shared object scanner {
 		switch (scope)
 		case (is ClassDeclaration) {
 			{FunctionOrValueDeclaration*} members = scope.declaredMemberDeclarations<ClassDeclaration|FunctionOrValueDeclaration>()
+					.chain(scope.memberDeclarations<ClassDeclaration|FunctionOrValueDeclaration>())
+					.distinct
 					.flatMap((Scope element) => single(element));
 			return members;
 		}
@@ -34,7 +36,7 @@ shared object scanner {
 	}
 	"Scans included [[inclusions]], reduced by excluded [[exclusions]] producing sequence of declarations for transformations into [[Dependency]]. 
 	 Only declarations annotated with [[dependency]] and they container classes are taken in consideration"
-	shared FunctionOrValueDeclaration[] scan({Scope*} inclusions, {Scope*} exclusions=[]) {
+	shared FunctionOrValueDeclaration[] dependencies({Scope*} inclusions, {Scope*} exclusions=[]) {
 		[FunctionOrValueDeclaration+]|[] excluded = exclusions.flatMap((Scope element) => single(element)).sequence();
 		return inclusions.flatMap((Scope element) => single(element))
 				.filter((Declaration element) => !excluded.contains(element)).sequence();

--- a/test/test/herd/depin/engine/integration/ScannerSunnyTest.ceylon
+++ b/test/test/herd/depin/engine/integration/ScannerSunnyTest.ceylon
@@ -1,0 +1,29 @@
+import ceylon.test {
+
+	testExtension,
+	test
+}
+import depin.test.extension {
+
+	LoggingTestExtension
+}
+import herd.depin.core {
+
+	scanner
+}
+import test.herd.depin.engine.integration.dependency {
+	ExtendingClass
+}
+
+testExtension (`class LoggingTestExtension`)
+shared class ScannerSunnyTest(){
+	
+	
+	
+	shared test void shouldScannInhertiedDependencies(){
+		value result=scanner.dependencies({`class ExtendingClass`});
+		assert(result.contains(`value ExtendingClass.name`));
+		assert(result.contains(`value ExtendingClass.age`));
+	}
+	
+}

--- a/test/test/herd/depin/engine/integration/SunnyInjectionTest.ceylon
+++ b/test/test/herd/depin/engine/integration/SunnyInjectionTest.ceylon
@@ -82,7 +82,7 @@ shared class SunnyInjectionTest() {
 
 	
 	shared test void shouldInjectExposedInterface(){
-		value declarations=scanner.scan({`package test.herd.depin.engine.integration.dependency.unshared`});
+		value declarations=scanner.dependencies({`package test.herd.depin.engine.integration.dependency.unshared`});
 		assert(Depin(declarations).inject(`ExposedTarget`).exposing.exposed==fixture.unshared.exposed);
 	}
 	

--- a/test/test/herd/depin/engine/integration/dependency/inherteadDependency.ceylon
+++ b/test/test/herd/depin/engine/integration/dependency/inherteadDependency.ceylon
@@ -1,0 +1,17 @@
+import test.herd.depin.engine.integration {
+
+	fixture
+}
+import herd.depin.core {
+
+	dependency
+}
+shared class BaseClass(
+	shared dependency String name
+){
+	
+}
+
+shared class ExtendingClass() extends BaseClass(fixture.person.john.name){
+	shared dependency Integer age=fixture.person.john.age;
+}


### PR DESCRIPTION
also on base clases (#60), renamed scanner.scan to scanner.depdendencies
as scanner may be used in the future for other purposes